### PR TITLE
make compatible w/ c++17

### DIFF
--- a/include/Criteria/Crit2_DeltaPhi.h
+++ b/include/Criteria/Crit2_DeltaPhi.h
@@ -18,7 +18,7 @@ namespace KiTrack{
       
       Crit2_DeltaPhi ( float deltaPhiMin , float deltaPhiMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit2_DeltaPhi(){};
 

--- a/include/Criteria/Crit2_DeltaPhi_MV.h
+++ b/include/Criteria/Crit2_DeltaPhi_MV.h
@@ -18,7 +18,7 @@ namespace KiTrack{
       
       Crit2_DeltaPhi_MV ( float deltaPhiMin , float deltaPhiMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit2_DeltaPhi_MV(){};
 

--- a/include/Criteria/Crit2_DeltaRho.h
+++ b/include/Criteria/Crit2_DeltaRho.h
@@ -16,7 +16,7 @@ namespace KiTrack{
       
       Crit2_DeltaRho ( float deltaRhoMin , float deltaRhoMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit2_DeltaRho(){};
       

--- a/include/Criteria/Crit2_DeltaTheta_MV.h
+++ b/include/Criteria/Crit2_DeltaTheta_MV.h
@@ -18,7 +18,7 @@ namespace KiTrack{
       
       Crit2_DeltaTheta_MV ( float deltaThetaMin , float deltaThetaMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit2_DeltaTheta_MV(){};
 

--- a/include/Criteria/Crit2_Distance_MV.h
+++ b/include/Criteria/Crit2_Distance_MV.h
@@ -18,7 +18,7 @@ namespace KiTrack{
       
       Crit2_Distance_MV ( float deltaPos2Min , float deltaPos2Max );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit2_Distance_MV(){};
 

--- a/include/Criteria/Crit2_HelixWithIP.h
+++ b/include/Criteria/Crit2_HelixWithIP.h
@@ -23,7 +23,7 @@ namespace KiTrack{
       
       Crit2_HelixWithIP ( float ratioMin , float ratioMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit2_HelixWithIP(){};
 

--- a/include/Criteria/Crit2_RZRatio.h
+++ b/include/Criteria/Crit2_RZRatio.h
@@ -17,7 +17,7 @@ namespace KiTrack{
       
       Crit2_RZRatio ( float ratioMin, float ratioMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit2_RZRatio(){};
     

--- a/include/Criteria/Crit2_StraightTrackRatio.h
+++ b/include/Criteria/Crit2_StraightTrackRatio.h
@@ -21,7 +21,7 @@ namespace KiTrack{
       
       Crit2_StraightTrackRatio ( float ratioMin, float ratioMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit2_StraightTrackRatio(){};
 

--- a/include/Criteria/Crit3_2DAngle.h
+++ b/include/Criteria/Crit3_2DAngle.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit3_2DAngle ( float angleMin, float angleMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit3_2DAngle(){};
     

--- a/include/Criteria/Crit3_2DAngleTimesR.h
+++ b/include/Criteria/Crit3_2DAngleTimesR.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit3_2DAngleTimesR ( float angleMin, float angleMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit3_2DAngleTimesR(){};
     

--- a/include/Criteria/Crit3_3DAngle.h
+++ b/include/Criteria/Crit3_3DAngle.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit3_3DAngle ( float angleMin, float angleMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit3_3DAngle(){};
     

--- a/include/Criteria/Crit3_3DAngleTimesR.h
+++ b/include/Criteria/Crit3_3DAngleTimesR.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit3_3DAngleTimesR ( float angleMin, float angleMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
 
       virtual ~Crit3_3DAngleTimesR(){};
     

--- a/include/Criteria/Crit3_ChangeRZRatio.h
+++ b/include/Criteria/Crit3_ChangeRZRatio.h
@@ -16,7 +16,7 @@ namespace KiTrack{
       
       Crit3_ChangeRZRatio ( float minChange , float maxChange );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit3_ChangeRZRatio(){};
       

--- a/include/Criteria/Crit3_IPCircleDist.h
+++ b/include/Criteria/Crit3_IPCircleDist.h
@@ -16,7 +16,7 @@ namespace KiTrack{
       
       Crit3_IPCircleDist ( float distToCircleMin , float distToCircleMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit3_IPCircleDist(){};
       

--- a/include/Criteria/Crit3_IPCircleDistTimesR.h
+++ b/include/Criteria/Crit3_IPCircleDistTimesR.h
@@ -16,7 +16,7 @@ namespace KiTrack{
       
       Crit3_IPCircleDistTimesR ( float distToCircleMin , float distToCircleMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit3_IPCircleDistTimesR(){};
       

--- a/include/Criteria/Crit3_NoZigZag_MV.h
+++ b/include/Criteria/Crit3_NoZigZag_MV.h
@@ -23,7 +23,7 @@ namespace KiTrack{
        */
       Crit3_NoZigZag_MV ( float prodMin , float prodMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit3_NoZigZag_MV(){};
       

--- a/include/Criteria/Crit3_PT.h
+++ b/include/Criteria/Crit3_PT.h
@@ -16,7 +16,7 @@ namespace KiTrack{
       
       Crit3_PT ( float ptMin , float ptMax , float Bz = 3.5 );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit3_PT(){};
       

--- a/include/Criteria/Crit3_PT_MV.h
+++ b/include/Criteria/Crit3_PT_MV.h
@@ -16,7 +16,7 @@ namespace KiTrack{
       
       Crit3_PT_MV ( float ptMin , float ptMax , float Bz = 3.5 );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit3_PT_MV(){};
       

--- a/include/Criteria/Crit4_2DAngleChange.h
+++ b/include/Criteria/Crit4_2DAngleChange.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit4_2DAngleChange ( float changeMin , float changeMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit4_2DAngleChange(){};
       

--- a/include/Criteria/Crit4_3DAngleChange.h
+++ b/include/Criteria/Crit4_3DAngleChange.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit4_3DAngleChange ( float changeMin , float changeMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit4_3DAngleChange(){};
       

--- a/include/Criteria/Crit4_3DAngleChangeNormed.h
+++ b/include/Criteria/Crit4_3DAngleChangeNormed.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit4_3DAngleChangeNormed ( float changeMin , float changeMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit4_3DAngleChangeNormed(){};
       

--- a/include/Criteria/Crit4_DistOfCircleCenters.h
+++ b/include/Criteria/Crit4_DistOfCircleCenters.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit4_DistOfCircleCenters ( float distMin , float distMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit4_DistOfCircleCenters(){};
       

--- a/include/Criteria/Crit4_DistToExtrapolation.h
+++ b/include/Criteria/Crit4_DistToExtrapolation.h
@@ -21,7 +21,7 @@ namespace KiTrack{
        */
       Crit4_DistToExtrapolation ( float distMin , float distMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit4_DistToExtrapolation(){};
       

--- a/include/Criteria/Crit4_NoZigZag.h
+++ b/include/Criteria/Crit4_NoZigZag.h
@@ -23,7 +23,7 @@ namespace KiTrack{
        */
       Crit4_NoZigZag ( float prodMin , float prodMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit4_NoZigZag(){};
       

--- a/include/Criteria/Crit4_PhiZRatioChange.h
+++ b/include/Criteria/Crit4_PhiZRatioChange.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit4_PhiZRatioChange ( float changeMin , float changeMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit4_PhiZRatioChange(){};
       

--- a/include/Criteria/Crit4_RChange.h
+++ b/include/Criteria/Crit4_RChange.h
@@ -19,7 +19,7 @@ namespace KiTrack{
        */
       Crit4_RChange ( float changeMin , float changeMax );
       
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength );
+      virtual bool areCompatible( Segment* parent , Segment* child );
       
       virtual ~Crit4_RChange(){};
       

--- a/include/Criteria/Criteria.h
+++ b/include/Criteria/Criteria.h
@@ -85,7 +85,7 @@ namespace KiTrack{
        * 
        * @return a "new" Criterion (i.e. needs to be deleted later on)
        */
-      static ICriterion* createCriterion( std::string critName , float min=0. , float max=0. )throw (UnknownCriterion) ;
+      static ICriterion* createCriterion( std::string critName , float min=0. , float max=0. ) ;
       
       /**
        * Sets values for the passed referneced floats left and right. They indicate how

--- a/include/Criteria/ICriterion.h
+++ b/include/Criteria/ICriterion.h
@@ -25,7 +25,7 @@ namespace KiTrack{
       /** @return If the two Segments are compatible with each other, i.e. could be combined to a longer Segment or a 
        * track.
        */
-      virtual bool areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ) = 0;
+      virtual bool areCompatible( Segment* parent , Segment* child ) = 0;
       
       
       /** @return A map, where the calculated values are stored. The keys are the names of the values.

--- a/include/Criteria/SimpleCircle.h
+++ b/include/Criteria/SimpleCircle.h
@@ -17,7 +17,7 @@ class SimpleCircle {
   public:
       
     
-      SimpleCircle ( double x1 , double y1 , double x2 , double y2 , double x3, double y3 ) throw( InvalidParameter );
+      SimpleCircle ( double x1 , double y1 , double x2 , double y2 , double x3, double y3 ) ;
       
       double getRadius() {return _R;};
       double getCenterX() {return _centerX;};

--- a/include/KiTrack/HopfieldNeuralNet.h
+++ b/include/KiTrack/HopfieldNeuralNet.h
@@ -34,7 +34,7 @@ namespace KiTrack{
          * between 0 and 1. 0 means, no influence from the quality of the neurons -> system tends to biggest compatible 
          * set. 1 means highest influence from the quality of the neurons -> the highest quality neurons tend to win.
          */
-         HopfieldNeuralNet( std::vector < std::vector <bool> > G , std::vector < double > QI , std::vector < double > states , double omega) throw( InvalidParameter );
+         HopfieldNeuralNet( std::vector < std::vector <bool> > G , std::vector < double > QI , std::vector < double > states , double omega) ;
                
                
          /** Does one iteration of the neuronal network.

--- a/include/KiTrack/ISectorSystem.h
+++ b/include/KiTrack/ISectorSystem.h
@@ -27,7 +27,7 @@ namespace KiTrack{
    public:
       
       /** @return the layer of the corresponding sector. */
-      virtual unsigned getLayer( int sector ) const throw ( OutOfRange ) =0;
+      virtual unsigned getLayer( int sector ) const  =0;
       
       /** @return the number of layers in the sector system. */
       unsigned getNumberOfLayers() const { return _nLayers; };

--- a/include/KiTrack/KiTrackExceptions.h
+++ b/include/KiTrack/KiTrackExceptions.h
@@ -22,13 +22,13 @@ namespace KiTrack {
     KiTrackException(){  /*no_op*/ ; } 
     
   public: 
-     virtual ~KiTrackException() throw() { /*no_op*/; } 
+     virtual ~KiTrackException()  { /*no_op*/; } 
     
     KiTrackException( const std::string& text ){
       message = "KiTrack::Exception: " + text ;
     }
 
-    virtual const char* what() const  throw() { return  message.c_str() ; } 
+    virtual const char* what() const  noexcept { return  message.c_str() ; } 
 
   };
 
@@ -42,7 +42,7 @@ namespace KiTrack {
   protected:
     OutOfRange() {  /*no_op*/ ; } 
   public: 
-    virtual ~OutOfRange() throw() { /*no_op*/; } 
+    virtual ~OutOfRange()  { /*no_op*/; } 
 
     OutOfRange( std::string text ){
       message = "KiTrack::OutOfRange: " + text ;
@@ -58,7 +58,7 @@ namespace KiTrack {
   protected:
      InvalidParameter() {  /*no_op*/ ; } 
   public: 
-     virtual ~InvalidParameter() throw() { /*no_op*/; } 
+     virtual ~InvalidParameter()  { /*no_op*/; } 
      
      InvalidParameter( std::string text ){
         message = "KiTrack::InvalidParameter: " + text ;
@@ -74,7 +74,7 @@ namespace KiTrack {
   protected:
      BadSegmentLength() {  /*no_op*/ ; } 
   public: 
-     virtual ~BadSegmentLength() throw() { /*no_op*/; } 
+     virtual ~BadSegmentLength()  { /*no_op*/; } 
      
      BadSegmentLength( std::string text ){
         message = "KiTrack::BadSegmentLength: " + text ;
@@ -91,7 +91,7 @@ namespace KiTrack {
   protected:
      UnknownCriterion() {  /*no_op*/ ; } 
   public: 
-     virtual ~UnknownCriterion() throw() { /*no_op*/; } 
+     virtual ~UnknownCriterion()  { /*no_op*/; } 
      
      UnknownCriterion( std::string text ){
         message = "KiTrack::UnknownCriterion: " + text ;

--- a/src/Criteria/Crit2_DeltaPhi.cc
+++ b/src/Criteria/Crit2_DeltaPhi.cc
@@ -19,7 +19,7 @@ Crit2_DeltaPhi::Crit2_DeltaPhi ( float deltaPhiMin , float deltaPhiMax ){
 
 
 
-bool Crit2_DeltaPhi::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit2_DeltaPhi::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit2_DeltaPhi_MV.cc
+++ b/src/Criteria/Crit2_DeltaPhi_MV.cc
@@ -19,7 +19,7 @@ Crit2_DeltaPhi_MV::Crit2_DeltaPhi_MV ( float deltaPhiMin , float deltaPhiMax ){
 
 
 
-bool Crit2_DeltaPhi_MV::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit2_DeltaPhi_MV::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit2_DeltaRho.cc
+++ b/src/Criteria/Crit2_DeltaRho.cc
@@ -20,7 +20,7 @@ Crit2_DeltaRho::Crit2_DeltaRho ( float deltaRhoMin , float deltaRhoMax ){
 
 
       
-bool Crit2_DeltaRho::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit2_DeltaRho::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit2_DeltaTheta_MV.cc
+++ b/src/Criteria/Crit2_DeltaTheta_MV.cc
@@ -20,7 +20,7 @@ Crit2_DeltaTheta_MV::Crit2_DeltaTheta_MV ( float deltaThetaMin , float deltaThet
 
 
 
-bool Crit2_DeltaTheta_MV::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit2_DeltaTheta_MV::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit2_Distance_MV.cc
+++ b/src/Criteria/Crit2_Distance_MV.cc
@@ -19,7 +19,7 @@ Crit2_Distance_MV::Crit2_Distance_MV ( float deltaPos2Min , float deltaPos2Max )
 
 
 
-bool Crit2_Distance_MV::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit2_Distance_MV::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit2_HelixWithIP.cc
+++ b/src/Criteria/Crit2_HelixWithIP.cc
@@ -22,7 +22,7 @@ Crit2_HelixWithIP::Crit2_HelixWithIP ( float ratioMin , float ratioMax ){
 
 
       
-bool Crit2_HelixWithIP::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit2_HelixWithIP::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit2_RZRatio.cc
+++ b/src/Criteria/Crit2_RZRatio.cc
@@ -22,7 +22,7 @@ Crit2_RZRatio::Crit2_RZRatio ( float ratioMin, float ratioMax ){
 }
 
   
-bool Crit2_RZRatio::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit2_RZRatio::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit2_StraightTrackRatio.cc
+++ b/src/Criteria/Crit2_StraightTrackRatio.cc
@@ -20,7 +20,7 @@ Crit2_StraightTrackRatio::Crit2_StraightTrackRatio ( float ratioMin, float ratio
 
 
       
-bool Crit2_StraightTrackRatio::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit2_StraightTrackRatio::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit3_2DAngle.cc
+++ b/src/Criteria/Crit3_2DAngle.cc
@@ -20,7 +20,7 @@ Crit3_2DAngle::Crit3_2DAngle ( float angleMin, float angleMax ){
 
 
       
-bool Crit3_2DAngle::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_2DAngle::areCompatible( Segment* parent , Segment* child ) {
    
    
    //this is not written very beautiful, because this code gets called often and needs to be fast.

--- a/src/Criteria/Crit3_2DAngleTimesR.cc
+++ b/src/Criteria/Crit3_2DAngleTimesR.cc
@@ -23,7 +23,7 @@ Crit3_2DAngleTimesR::Crit3_2DAngleTimesR ( float angleMin, float angleMax ){
 
 
       
-bool Crit3_2DAngleTimesR::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_2DAngleTimesR::areCompatible( Segment* parent , Segment* child ) {
    
    
    //this is not written very beautiful, because this code gets called often and needs to be fast.

--- a/src/Criteria/Crit3_3DAngle.cc
+++ b/src/Criteria/Crit3_3DAngle.cc
@@ -20,7 +20,7 @@ Crit3_3DAngle::Crit3_3DAngle ( float angleMin, float angleMax ){
 
 
       
-bool Crit3_3DAngle::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_3DAngle::areCompatible( Segment* parent , Segment* child ) {
    
    
    //this is not written very beautiful, because this code gets called often and needs to be fast.

--- a/src/Criteria/Crit3_3DAngleTimesR.cc
+++ b/src/Criteria/Crit3_3DAngleTimesR.cc
@@ -23,7 +23,7 @@ Crit3_3DAngleTimesR::Crit3_3DAngleTimesR ( float angleMin, float angleMax ){
 
 
       
-bool Crit3_3DAngleTimesR::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_3DAngleTimesR::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit3_ChangeRZRatio.cc
+++ b/src/Criteria/Crit3_ChangeRZRatio.cc
@@ -21,7 +21,7 @@ Crit3_ChangeRZRatio::Crit3_ChangeRZRatio( float minChange , float maxChange ){
 
 
 
-bool Crit3_ChangeRZRatio::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_ChangeRZRatio::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit3_IPCircleDist.cc
+++ b/src/Criteria/Crit3_IPCircleDist.cc
@@ -23,7 +23,7 @@ Crit3_IPCircleDist::Crit3_IPCircleDist( float distToCircleMin , float distToCirc
 
 
 
-bool Crit3_IPCircleDist::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_IPCircleDist::areCompatible( Segment* parent , Segment* child ) {
    
 
    

--- a/src/Criteria/Crit3_IPCircleDistTimesR.cc
+++ b/src/Criteria/Crit3_IPCircleDistTimesR.cc
@@ -23,7 +23,7 @@ Crit3_IPCircleDistTimesR::Crit3_IPCircleDistTimesR( float distToCircleMin , floa
 
 
 
-bool Crit3_IPCircleDistTimesR::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_IPCircleDistTimesR::areCompatible( Segment* parent , Segment* child ) {
    
 
    

--- a/src/Criteria/Crit3_NoZigZag_MV.cc
+++ b/src/Criteria/Crit3_NoZigZag_MV.cc
@@ -23,7 +23,7 @@ Crit3_NoZigZag_MV::Crit3_NoZigZag_MV ( float prodMin , float prodMax ){
 
 
 
-bool Crit3_NoZigZag_MV::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_NoZigZag_MV::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit3_PT.cc
+++ b/src/Criteria/Crit3_PT.cc
@@ -23,7 +23,7 @@ Crit3_PT::Crit3_PT( float ptMin , float ptMax , float Bz ){
 
 
 
-bool Crit3_PT::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_PT::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit3_PT_MV.cc
+++ b/src/Criteria/Crit3_PT_MV.cc
@@ -23,7 +23,7 @@ Crit3_PT_MV::Crit3_PT_MV( float ptMin , float ptMax , float Bz ){
 
 
 
-bool Crit3_PT_MV::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit3_PT_MV::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit4_2DAngleChange.cc
+++ b/src/Criteria/Crit4_2DAngleChange.cc
@@ -23,7 +23,7 @@ Crit4_2DAngleChange::Crit4_2DAngleChange ( float changeMin , float changeMax ){
 
 
 
-bool Crit4_2DAngleChange::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit4_2DAngleChange::areCompatible( Segment* parent , Segment* child ) {
     
       
    if (( parent->getHits().size() == 3 )&&( child->getHits().size() == 3 )){ //this is a criterion for 3-segments

--- a/src/Criteria/Crit4_3DAngleChange.cc
+++ b/src/Criteria/Crit4_3DAngleChange.cc
@@ -23,7 +23,7 @@ Crit4_3DAngleChange::Crit4_3DAngleChange ( float changeMin , float changeMax ){
 
 
 
-bool Crit4_3DAngleChange::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit4_3DAngleChange::areCompatible( Segment* parent , Segment* child ) {
     
       
    if (( parent->getHits().size() == 3 )&&( child->getHits().size() == 3 )){ //this is a criterion for 3-segments

--- a/src/Criteria/Crit4_3DAngleChangeNormed.cc
+++ b/src/Criteria/Crit4_3DAngleChangeNormed.cc
@@ -24,7 +24,7 @@ Crit4_3DAngleChangeNormed::Crit4_3DAngleChangeNormed ( float changeMin , float c
 
 
 
-bool Crit4_3DAngleChangeNormed::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit4_3DAngleChangeNormed::areCompatible( Segment* parent , Segment* child ) {
    
 
    if (( parent->getHits().size() == 3 )&&( child->getHits().size() == 3 )){ //this is a criterion for 3-segments

--- a/src/Criteria/Crit4_DistOfCircleCenters.cc
+++ b/src/Criteria/Crit4_DistOfCircleCenters.cc
@@ -24,7 +24,7 @@ Crit4_DistOfCircleCenters::Crit4_DistOfCircleCenters ( float distMin , float dis
 
 
 
-bool Crit4_DistOfCircleCenters::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit4_DistOfCircleCenters::areCompatible( Segment* parent , Segment* child ) {
     
    
    

--- a/src/Criteria/Crit4_DistToExtrapolation.cc
+++ b/src/Criteria/Crit4_DistToExtrapolation.cc
@@ -25,7 +25,7 @@ Crit4_DistToExtrapolation::Crit4_DistToExtrapolation ( float distMin , float dis
 
 
 
-bool Crit4_DistToExtrapolation::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit4_DistToExtrapolation::areCompatible( Segment* parent , Segment* child ) {
     
    
    

--- a/src/Criteria/Crit4_NoZigZag.cc
+++ b/src/Criteria/Crit4_NoZigZag.cc
@@ -23,7 +23,7 @@ Crit4_NoZigZag::Crit4_NoZigZag ( float prodMin , float prodMax ){
 
 
 
-bool Crit4_NoZigZag::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit4_NoZigZag::areCompatible( Segment* parent , Segment* child ) {
    
    
    

--- a/src/Criteria/Crit4_PhiZRatioChange.cc
+++ b/src/Criteria/Crit4_PhiZRatioChange.cc
@@ -25,7 +25,7 @@ Crit4_PhiZRatioChange::Crit4_PhiZRatioChange ( float changeMin , float changeMax
 
 
 
-bool Crit4_PhiZRatioChange::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit4_PhiZRatioChange::areCompatible( Segment* parent , Segment* child ) {
     
    
    

--- a/src/Criteria/Crit4_RChange.cc
+++ b/src/Criteria/Crit4_RChange.cc
@@ -24,7 +24,7 @@ Crit4_RChange::Crit4_RChange ( float changeMin , float changeMax ){
 
 
 
-bool Crit4_RChange::areCompatible( Segment* parent , Segment* child )throw( BadSegmentLength ){
+bool Crit4_RChange::areCompatible( Segment* parent , Segment* child ) {
     
    
    

--- a/src/Criteria/Criteria.cc
+++ b/src/Criteria/Criteria.cc
@@ -99,7 +99,7 @@ std::set< std::string > Criteria::getCriteriaNames( std::string type ){
 }
 
 
-ICriterion* Criteria::createCriterion( std::string critName, float min , float max ) throw (UnknownCriterion){
+ICriterion* Criteria::createCriterion( std::string critName, float min , float max ) {
    
    
    

--- a/src/Criteria/SimpleCircle.cc
+++ b/src/Criteria/SimpleCircle.cc
@@ -7,7 +7,7 @@
 
 using namespace KiTrack;
 
-SimpleCircle::SimpleCircle( double x1 , double y1 , double x2 , double y2 , double x3, double y3 ) throw( InvalidParameter ){
+SimpleCircle::SimpleCircle( double x1 , double y1 , double x2 , double y2 , double x3, double y3 ) {
   
   
    

--- a/src/KiTrack/HopfieldNeuralNet.cc
+++ b/src/KiTrack/HopfieldNeuralNet.cc
@@ -4,11 +4,12 @@
 #include <iostream>
 #include <algorithm>
 #include <sstream>
+#include <random>
 
 
 using namespace KiTrack;
 
-HopfieldNeuralNet::HopfieldNeuralNet( std::vector < std::vector <bool> > G , std::vector < double > QI , std::vector < double > states , double omega) throw( InvalidParameter ){
+HopfieldNeuralNet::HopfieldNeuralNet( std::vector < std::vector <bool> > G , std::vector < double > QI , std::vector < double > states , double omega) {
 
    unsigned int nNeurons = G.size();
 
@@ -139,7 +140,7 @@ HopfieldNeuralNet::HopfieldNeuralNet( std::vector < std::vector <bool> > G , std
    
    _isStable = false;
    _limitForStable = 0.01;
-   
+
 
 
 }
@@ -166,8 +167,11 @@ bool HopfieldNeuralNet::doIteration(){
    
    _isStable = true;
    
-   
-   random_shuffle ( _order.begin() , _order.end() ); //shuffle the order
+   // initialize the random generator
+   std::random_device rng;
+   std::mt19937 urng(rng());
+
+   shuffle ( _order.begin() , _order.end() , urng ); //shuffle the order
    
    for (unsigned int i=0; i<_States.size() ; i++){ //for all entries of the vector
       


### PR DESCRIPTION
 BEGINRELEASENOTES
- make compatible w/ c++17
      - remove all throw() declarations
      - replace std::random_shuffle w/ std::shuffle<..., std::mt19937>

ENDRELEASENOTES