### PR TITLE
Link to streamlog instead of Marlin_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ INCLUDE( ilcsoft_default_settings )
 
 FIND_PACKAGE( Marlin 1.0 REQUIRED ) # minimum required Marlin version
 INCLUDE_DIRECTORIES( ${Marlin_INCLUDE_DIRS} )
-LINK_LIBRARIES( ${Marlin_LIBRARIES} )
+LINK_LIBRARIES( streamlog )
 ADD_DEFINITIONS( ${Marlin_DEFINITIONS} )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ INCLUDE( ilcsoft_default_settings )
 
 FIND_PACKAGE( Marlin 1.0 REQUIRED ) # minimum required Marlin version
 INCLUDE_DIRECTORIES( ${Marlin_INCLUDE_DIRS} )
-LINK_LIBRARIES( streamlog )
+LINK_LIBRARIES( streamlog::streamlog )
 ADD_DEFINITIONS( ${Marlin_DEFINITIONS} )
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Link to `streamlog` instead of `Marlin_LIBRARIES`. 

ENDRELEASENOTES

Uncovered by https://github.com/iLCSoft/Marlin/pull/56, only `streamlog` is needed by `KiTrack`.